### PR TITLE
Add logic to ensure configs are lowercase

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -211,6 +211,7 @@ echo "== Installing... =="
 sudo tar -xf deps/k3os-rootfs-arm64.tar.gz --strip 1 -C root
 # config.yaml will be created by init.resizefs based on MAC of eth0
 sudo cp -R config root/k3os/system
+for filename in root/k3os/system/config/*.*; do [ "$filename" != "${filename,,}" ] && sudo mv "$filename" "${filename,,}" ; done 
 K3OS_VERSION=$(ls --indicator-style=none root/k3os/system/k3os | grep -v current | head -n1)
 
 ## Install busybox


### PR DESCRIPTION
A quick fix to rename config files from upper to lower case to prevent the issue described in https://github.com/sgielen/picl-k3os-image-generator/issues/8#issue-588525019

I thought it was less clunky to add logic here than in the resizefs script. Additionally, the *.* was used to try to prevent renaming any potential directories since .yaml may also be capitalized.