### PR TITLE
Update to always pull latest raspberry pi firmware from github using API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project can be used to generate images for k3os compatible with various arm
 
 - First, make a list of devices you want to use in your k3s cluster, their hardware types and the MAC addresses of their eth0 interface. (To find the MAC, boot any supported OS, perhaps the one that comes on the included SD card if you have one, and `cat /sys/class/net/eth0/address`. Or, just continue with a dummy config and the initial boot will say "there is no config for MAC xx:xx:xx:xx:xx:xx", and then you know what to call it.)
 - In the config/ directory, create one configuration file for each device, named as `{MAC}.yaml` (e.g. `dc:a6:32:aa:bb:cc.yaml`). The appropriate file will be used as a config.yaml eventually.
+- For Raspberry Pi devices, you can choose which firmware to use for the build by setting an env variable `RASPBERRY_PI_FIRMWARE`
+    - If unset, the script uses a known good version (set as `DEFAULT_GOOD_PI_VERSION` in the script)
+    - Set to `latest`, which instructs the script to always pull the latest version available in the raspberry pi firmware repo (e.g. `export RASPBERRY_PI_FIRMWARE=latest`)
+    - Set to a specific version, which instructs the script to use that version (e.g. `export RASPBERRY_PI_FIRMWARE="1.20200212"`)
 - Run `./build-image.sh <imagetype>` where imagetype is `raspberrypi` or `orangepipc2`. It will check whether all dependencies are installed for creating the image, then proceeds to create the image as `picl-k3os-{k3osversion}-{imagetype}.img`.
   - If you have multiple images, you can also run `./build-image.sh all` to build all supported image types in one go for convenience.
 - Write the image to the SD cards for each device. The SD card must be at least 1 GB.

--- a/build-image.sh
+++ b/build-image.sh
@@ -18,6 +18,37 @@ assert_tool() {
 	fi
 }
 
+get_pifirmware() {
+    #  Uses RASPBERRY_PI_FIRMWARE env variable to allow the user to control which pi firmware version to use.
+    # - 1. unset, in which case it is initialized to a known good version (DEFAULT_GOOD_PI_VERSION)
+    # - 2. set to "latest" in which case it pulls the latest firmware from git repo.
+    # - 3. set by the user to desired version
+
+    # Set this to default to a KNOWN GOOD pi firmware (e.g. 1.20200212); this is used if RASPBERRY_PI_FIRMWARE env variable is not specified
+    DEFAULT_GOOD_PI_VERSION="1.20200212"
+
+    if [ -z "${RASPBERRY_PI_FIRMWARE}" ]; then
+        echo "RASPBERRY_PI_FIRMWARE env variable was not set - defaulting to known good firmware [${DEFAULT_GOOD_PI_VERSION}]"
+        dl_dep raspberrypi-firmware.tar.gz https://github.com/raspberrypi/firmware/archive/"${DEFAULT_GOOD_PI_VERSION}".tar.gz
+    elif [ "${RASPBERRY_PI_FIRMWARE}" = "latest" ]; then
+        echo "RASPBERRY_PI_FIRMWARE env variable set to 'latest' - using latest pi firmware release"
+        dl_dep raspberrypi-firmware.tar.gz "$(wget -qO - https://api.github.com/repos/raspberrypi/firmware/tags | jq -r '.[0].tarball_url')"
+    else
+        # set to requested version, but first check if it is a valid version
+        for i in $(wget -qO - https://api.github.com/repos/raspberrypi/firmware/tags | jq  --arg RASPBERRY_PI_FIRMWARE "${RASPBERRY_PI_FIRMWARE}" -r '.[].tarball_url | contains($RASPBERRY_PI_FIRMWARE)')
+        do
+            if [ "$i" = "true" ]; then FOUND=true; break; fi
+        done
+        if [ "${FOUND}" = true ]; then
+            echo "RASPBERRY_PI_FIRMWARE env variable set to [${RASPBERRY_PI_FIRMWARE}] - will use this firmware."
+            dl_dep raspberrypi-firmware.tar.gz https://github.com/raspberrypi/firmware/archive/"${RASPBERRY_PI_FIRMWARE}".tar.gz
+        else
+            echo "Requested raspberry pi firmware [${RASPBERRY_PI_FIRMWARE}] is not valid (does not exist in pi firmware repo)! Exiting Build!"
+            exit 1;
+        fi
+    fi
+}
+
 assert_tool wget
 assert_tool mktemp
 assert_tool fallocate
@@ -76,7 +107,7 @@ function dl_dep() {
 mkdir -p deps
 
 if [ "$IMAGE_TYPE" = "raspberrypi" ]; then
-	dl_dep raspberrypi-firmware.tar.gz "$(wget -qO - https://api.github.com/repos/raspberrypi/firmware/tags | jq -r '.[0].tarball_url')"
+	get_pifirmware
 elif [ "$IMAGE_TYPE" = "orangepipc2" ]; then
 	# TODO: apt.armbian.com removes old versions, so these URLs become
 	# outdated. Find an armbian mirror that keeps old versions so that

--- a/build-image.sh
+++ b/build-image.sh
@@ -34,6 +34,7 @@ assert_tool blkid
 assert_tool realpath
 assert_tool 7z
 assert_tool dd
+assert_tool jq
 
 ## Check if we are building a supported image
 IMAGE_TYPE=$1
@@ -75,7 +76,7 @@ function dl_dep() {
 mkdir -p deps
 
 if [ "$IMAGE_TYPE" = "raspberrypi" ]; then
-	dl_dep raspberrypi-firmware.tar.gz https://github.com/raspberrypi/firmware/archive/1.20200212.tar.gz
+	dl_dep raspberrypi-firmware.tar.gz "$(wget -qO - https://api.github.com/repos/raspberrypi/firmware/tags | jq -r '.[0].tarball_url')"
 elif [ "$IMAGE_TYPE" = "orangepipc2" ]; then
 	# TODO: apt.armbian.com removes old versions, so these URLs become
 	# outdated. Find an armbian mirror that keeps old versions so that


### PR DESCRIPTION
## What was changed / proposed change
Currently reving the firmware for the raspberrypi requires manually updating the [script](https://github.com/sgielen/picl-k3os-image-generator/blob/master/build-image.sh#L78).  This PR would instead use the github [api](https://api.github.com/repos/raspberrypi/firmware/tags) to always pull the latest firmware tarball eliminating this need.

### Update
 Per [comment](https://github.com/sgielen/picl-k3os-image-generator/pull/15#issuecomment-626897957) , added the ability to user select raspberry pi firmware version via an environment variable `RASPBERRY_PI_FIRMWARE`

- If unset, the script uses a known good version ( set as `DEFAULT_GOOD_PI_VERSION` in the script)
- Set to `latest` which instructs the script to always pull the latest version for the raspberry pi fimrware repo (e.g. `export RASPBERRY_PI_FIRMWARE=latest`)
- Set to a specific version which instructs the script to use that version (e.g. `export RASPBERRY_PI_FIRMWARE="1.20200212"`)
