### PR TITLE
Updated script to use v0.20.7-k3s1r0 of K3os as "Last known good version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This project can be used to generate images for k3os compatible with various arm
 ## Getting Started
 
 - First, make a list of devices you want to use in your k3s cluster, their hardware types and the MAC addresses of their eth0 interface. (To find the MAC, boot any supported OS, perhaps the one that comes on the included SD card if you have one, and `cat /sys/class/net/eth0/address`. Or, just continue with a dummy config and the initial boot will say "there is no config for MAC xx:xx:xx:xx:xx:xx", and then you know what to call it.)
-- In the config/ directory, create one configuration file for each device, named as `{MAC}.yaml` (e.g. `dc:a6:32:aa:bb:cc.yaml`). The appropriate file will be used as a config.yaml eventually.
+- Ensure git is installed: `sudo apt-get install git`
+- Clone the repo: `sudo git clone https://github.com/sgielen/picl-k3os-image-generator.git /opt/`
+- Navigate to the application `cd /opt/picl-k3os-image-generator` (required for invokingthe script)
+- Make the build script executable: `sudo chmod 751 build-image.sh`
+- In the `config/` directory, create one configuration file for each device, named as `{MAC}.yaml` (e.g. `dc:a6:32:aa:bb:cc.yaml`). The appropriate file will be used as a config.yaml eventually. Examples of these configs can be found in the `config-examples/` directory.
 - For Raspberry Pi devices, you can choose which firmware to use for the build by setting an env variable `RASPBERRY_PI_FIRMWARE`
     - If unset, the script uses a known good version (set as `DEFAULT_GOOD_PI_VERSION` in the script)
     - Set to `latest`, which instructs the script to always pull the latest version available in the raspberry pi firmware repo (e.g. `export RASPBERRY_PI_FIRMWARE=latest`)

--- a/build-image.sh
+++ b/build-image.sh
@@ -7,7 +7,7 @@ set -e
 DEFAULT_GOOD_PI_VERSION="1.20200811"
 
 # Set this to default to a KNOWN GOOD k3os (e.g. v0.11.0); this is used if K3OS_VERSION env variable is not specified
-DEFAULT_GOOD_K3OS_VERSION="v0.11.0"
+DEFAULT_GOOD_K3OS_VERSION="v0.20.7-k3s1r0"
 
 ## Check if we have any configs
 if [ -z "$(ls config/*.yaml)" ]; then

--- a/build-image.sh
+++ b/build-image.sh
@@ -3,8 +3,8 @@
 set -e
 
 
-# Set this to default to a KNOWN GOOD pi firmware (e.g. 1.20200811); this is used if RASPBERRY_PI_FIRMWARE env variable is not specified
-DEFAULT_GOOD_PI_VERSION="1.20200811"
+# Set this to default to a KNOWN GOOD pi firmware (e.g. 1.20210831); this is used if RASPBERRY_PI_FIRMWARE env variable is not specified
+DEFAULT_GOOD_PI_VERSION="1.20210831"
 
 # Set this to default to a KNOWN GOOD k3os (e.g. v0.11.0); this is used if K3OS_VERSION env variable is not specified
 DEFAULT_GOOD_K3OS_VERSION="v0.20.7-k3s1r0"

--- a/config-examples/dc:a6:32:16:e9:8b.yaml
+++ b/config-examples/dc:a6:32:16:e9:8b.yaml
@@ -1,9 +1,22 @@
-# n1
+# BACKPLANE
 ssh_authorized_keys:
 - ssh-rsa AAAAB3N...
-hostname: n1
+hostname: BACKPLANE
 k3os:
+  data_sources:
+    - aws
+    - cdrom
+  modules:
+    - kvm
+    - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+    - DNS_SERVER1
+    - DNS_SERVER2
   ntp_servers:
   - NTP_SERVER_IP_OR_HOSTNAME
   k3s_args:
   - server
+  - "--cluster-init"

--- a/config-examples/dc:a6:32:76:34:b5.yaml
+++ b/config-examples/dc:a6:32:76:34:b5.yaml
@@ -1,8 +1,20 @@
-# n2
+# Node_1
 ssh_authorized_keys:
 - ssh-rsa AAAAB3N...
-hostname: n2
+hostname: Node_1
 k3os:
+  data_sources:
+    - aws
+    - cdrom
+  modules:
+    - kvm
+    - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+    - DNS_SERVER1
+    - DNS_SERVER2
   ntp_servers:
   - NTP_SERVER_IP_OR_HOSTNAME
   k3s_args:

--- a/config-examples/dc:a6:32:76:34:eb.yaml
+++ b/config-examples/dc:a6:32:76:34:eb.yaml
@@ -1,8 +1,21 @@
-# n3
+
+# Node_2
 ssh_authorized_keys:
 - ssh-rsa AAAAB3N...
-hostname: n3
+hostname: Node_2
 k3os:
+  data_sources:
+    - aws
+    - cdrom
+  modules:
+    - kvm
+    - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+    - DNS_SERVER1
+    - DNS_SERVER2
   ntp_servers:
   - NTP_SERVER_IP_OR_HOSTNAME
   k3s_args:


### PR DESCRIPTION
Required some additional flags and variables being added to the config examples. Also renamed the config examples to be more specific regarding hostnames (Named the backplane "BACKPLANE" and the two nodes "NODE1" and "NODE2" respectively)

Confirmed working on both Raspberry Pi 4 and Raspberry Pi 3 Model B+