### PR TITLE
fix: upgrade uses `latest` (upstream change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To autoupgrade to new k3os versions you may enable the k3os upgrade feature by a
 ```
 k3os:
     labels:
-        k3os.io/upgrade: enabled
+        k3os.io/upgrade: latest
 
 ```
 

--- a/config-examples/dc:a6:32:16:e9:8b.yaml
+++ b/config-examples/dc:a6:32:16:e9:8b.yaml
@@ -8,4 +8,4 @@ k3os:
   k3s_args:
   - server
   labels:
-    k3os.io/upgrade: enabled
+    k3os.io/upgrade: latest

--- a/config-examples/dc:a6:32:76:34:b5.yaml
+++ b/config-examples/dc:a6:32:76:34:b5.yaml
@@ -10,4 +10,4 @@ k3os:
   token: MASTER_TOKEN
   server_url: https://MASTER_IP:6443
   labels:
-    k3os.io/upgrade: enabled
+    k3os.io/upgrade: latest

--- a/config-examples/dc:a6:32:76:34:eb.yaml
+++ b/config-examples/dc:a6:32:76:34:eb.yaml
@@ -10,4 +10,4 @@ k3os:
   token: MASTER_TOKEN
   server_url: https://MASTER_IP:6443
   labels:
-    k3os.io/upgrade: enabled
+    k3os.io/upgrade: latest


### PR DESCRIPTION
apply upstream change `enabled` to `latest` according to
https://github.com/rancher/k3os/commit/a9c866997db4f7fcf004e0dedf0aa5cc0dd37d80