### PR TITLE
allow script to continue, when quirks.txt doesn't exist

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -244,7 +244,7 @@ kernel=kernel8.img
 [all]
 EOF
 	PARTUUID=$(sudo blkid -o export $LODEV_ROOT | grep PARTUUID)
-	QUIRKS=$( [ -f quirks.txt ] && cat quirks.txt)
+	QUIRKS=$( [ -f quirks.txt ] && cat quirks.txt || true)
 	echo "dwc_otg.lpm_enable=0 root=$PARTUUID rootfstype=ext4 cgroup_memory=1 cgroup_enable=memory rootwait init=/sbin/init.resizefs ro $QUIRKS" | sudo tee boot/cmdline.txt >/dev/null
 	sudo rm -rf $PITEMP
 elif [ "$IMAGE_TYPE" = "orangepipc2" ]; then


### PR DESCRIPTION
PR #39 introduced a problem that prevented the build script from continuing when the `quirks.txt` file was missing.
This should fix the problematic behaviour.