### PR TITLE
Allow using environment variables in config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
     wget parted dosfstools binutils p7zip-full \
-    sudo xz-utils jq u-boot-tools
+    sudo xz-utils jq u-boot-tools gettext-base
 
 # The repository should be mounted at /app.
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project can be used to generate images for k3os compatible with various arm
 
 - First, make a list of devices you want to use in your k3s cluster, their hardware types and the MAC addresses of their eth0 interface. (To find the MAC, boot any supported OS, perhaps the one that comes on the included SD card if you have one, and `cat /sys/class/net/eth0/address`. Or, just continue with a dummy config and the initial boot will say "there is no config for MAC xx:xx:xx:xx:xx:xx", and then you know what to call it.)
 - In the config/ directory, create one configuration file for each device, named as `{MAC}.yaml` (e.g. `dc:a6:32:aa:bb:cc.yaml`). The appropriate file will be used as a config.yaml eventually.
+    - You can use environment variable references in these configuration files. During execution of `./build-image.sh` the references will be expanded via `envsubst`.
 - For Raspberry Pi devices, you can choose which firmware to use for the build by setting an env variable `RASPBERRY_PI_FIRMWARE`
     - If unset, the script uses a known good version (set as `DEFAULT_GOOD_PI_VERSION` in the script)
     - Set to `latest`, which instructs the script to always pull the latest version available in the raspberry pi firmware repo (e.g. `export RASPBERRY_PI_FIRMWARE=latest`)

--- a/build-image.sh
+++ b/build-image.sh
@@ -69,6 +69,7 @@ assert_tool blkid
 assert_tool 7z
 assert_tool dd
 assert_tool jq
+assert_tool envsubst
 
 ## Check if we are building a supported image
 IMAGE_TYPE=$1

--- a/build-image.sh
+++ b/build-image.sh
@@ -260,6 +260,11 @@ echo "== Installing... =="
 sudo tar -xf deps/k3os-rootfs-arm64.tar.gz --strip 1 -C root
 # config.yaml will be created by init.resizefs based on MAC of eth0
 sudo cp -R config root/k3os/system
+
+find "config/" -maxdepth 1 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file; do
+	envsubst < "$file" | sudo tee -a "root/k3os/system/$(basename "$file")" > /dev/null
+done
+
 for filename in root/k3os/system/config/*.*; do [ "$filename" != "${filename,,}" ] && sudo mv "$filename" "${filename,,}" ; done 
 K3OS_VERSION=$(ls --indicator-style=none root/k3os/system/k3os | grep -v current | head -n1)
 

--- a/build-image.sh
+++ b/build-image.sh
@@ -263,7 +263,7 @@ sudo tar -xf deps/k3os-rootfs-arm64.tar.gz --strip 1 -C root
 sudo cp -R config root/k3os/system
 
 find "config/" -maxdepth 1 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file; do
-	envsubst < "$file" | sudo tee -a "root/k3os/system/$(basename "$file")" > /dev/null
+	envsubst < "$file" | sudo tee "root/k3os/system/config/$(basename "$file")" > /dev/null
 done
 
 for filename in root/k3os/system/config/*.*; do [ "$filename" != "${filename,,}" ] && sudo mv "$filename" "${filename,,}" ; done 


### PR DESCRIPTION
I was looking for a way of managing my device configurations through git without exposing any secrets.
By using `envsubst` during `build-image.sh` it should be possible to separate the configuration from secret values and maintain those through other means.

For example:
```yaml
# in dc:a6:32:16:e9:8b.yaml
# ...
k3os:
  k3s_args:
  - server
  labels:
    k3os.io/upgrade: latest
  password: ${LOGIN_PASSWORD}
```
```bash
export LOGIN_PASSWORD=qwerty
./build-image.sh raspberrypi
```